### PR TITLE
Remove unnecessary location settings.

### DIFF
--- a/bigquery_client.go
+++ b/bigquery_client.go
@@ -8,21 +8,18 @@ import (
 )
 
 type BigQueryClient struct {
-	Project  string
-	Location string
-	client   *bigquery.Client
+	Project string
+	client  *bigquery.Client
 }
 
-func NewBigQueryClient(ctx context.Context, project, location string) (*BigQueryClient, error) {
+func NewBigQueryClient(ctx context.Context, project string) (*BigQueryClient, error) {
 	client, err := bigquery.NewClient(ctx, project)
 	if err != nil {
 		return nil, err
 	}
-	client.Location = location
 	return &BigQueryClient{
-		Project:  project,
-		Location: location,
-		client:   client,
+		Project: project,
+		client:  client,
 	}, nil
 }
 

--- a/cli.go
+++ b/cli.go
@@ -10,9 +10,8 @@ import (
 type CLI struct {
 	Version kong.VersionFlag `help:"Show version"`
 	Start   struct {
-		Project  string   `required:"" help:"Project ID"`
-		Location string   `default:"asia-northeast1" help:"Location"`
-		Dataset  []string `required:"" help:"Allowed datasets"`
+		Project string   `required:"" help:"Project ID"`
+		Dataset []string `required:"" help:"Allowed datasets"`
 	} `cmd:"" help:"Start the MCP BigQuery server"`
 }
 

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -21,7 +21,7 @@ const (
 )
 
 func StartServer(ctx context.Context, c *CLI) error {
-	bs, err := NewBigQueryServer(ctx, c.Start.Project, c.Start.Location, c.Start.Dataset)
+	bs, err := NewBigQueryServer(ctx, c.Start.Project, c.Start.Dataset)
 	if err != nil {
 		log.Fatalf("Failed to create server: %v", err)
 	}
@@ -32,7 +32,7 @@ func StartServer(ctx context.Context, c *CLI) error {
 	return nil
 }
 
-func NewBigQueryServer(ctx context.Context, project, location string, datasets []string) (*BigQueryServer, error) {
+func NewBigQueryServer(ctx context.Context, project string, datasets []string) (*BigQueryServer, error) {
 	s := &BigQueryServer{
 		server: server.NewMCPServer(
 			"bigquery-server",
@@ -41,7 +41,7 @@ func NewBigQueryServer(ctx context.Context, project, location string, datasets [
 		datasets: datasets,
 	}
 
-	client, err := NewBigQueryClient(ctx, project, location)
+	client, err := NewBigQueryClient(ctx, project)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The query fails due to missing tables when the location is set.